### PR TITLE
BUG_FIX in XMLDriver

### DIFF
--- a/src/org/alex73/osmemory/XMLDriver.java
+++ b/src/org/alex73/osmemory/XMLDriver.java
@@ -105,7 +105,7 @@ public class XMLDriver {
                     case "member":
                         Member m = new Member();
                         m.setType(attributes.getValue("type"));
-                        m.setRef(Long.parseLong(attributes.getValue("id")));
+                        m.setRef(Long.parseLong(attributes.getValue("ref")));
                         m.setRole(attributes.getValue("role"));
                         members.add(m);
                         break;


### PR DESCRIPTION
This commit fix a bug in the XMLDriver.
Before this commit read() try to get "ref" using attribute "id" in
"member" case; the rusult is an incorrect "ref".
This commit change "id" in "ref".

Signed-of-by: Filippo Muzzini <filippo.muzzini@outlook.it>